### PR TITLE
Custom brightness command

### DIFF
--- a/csmt/crankshaft
+++ b/csmt/crankshaft
@@ -349,120 +349,89 @@ if [ ! -z $1 ]; then
 
     # brightness
     if [ $1 == "brightness" ]; then
-        case $2 in
-	    save)
 		if [ -f ${BRIGHTNESS_FILE} ]; then
-		    cs_bootrw
-                    if [ -f /tmp/night_mode_enabled ]; then
-                        sudo sh -c 'cat '${BRIGHTNESS_FILE}' > '${CS_BRIGHTNESS_NIGHT_STORE_FILE}
-                        cs_echo "Brightness Level Night Saved"
-                    else
-                        sudo sh -c 'cat '${BRIGHTNESS_FILE}' > '${CS_BRIGHTNESS_STORE_FILE}
-                        cs_echo "Brightness Level Day Saved"
-		    fi
-
-		    cs_bootro
+			case $2 in
+				save)
+					cs_bootrw
+					if [ -f /tmp/night_mode_enabled ]; then
+						sudo sh -c 'cat '${BRIGHTNESS_FILE}' > '${CS_BRIGHTNESS_NIGHT_STORE_FILE}
+						cs_echo "Brightness Level Night Saved"
+					else
+						sudo sh -c 'cat '${BRIGHTNESS_FILE}' > '${CS_BRIGHTNESS_STORE_FILE}
+						cs_echo "Brightness Level Day Saved"
+					fi
+					cs_bootro
+					;;
+				restore)
+					if [ -f /tmp/night_mode_enabled ]; then
+						if [ -f ${CS_BRIGHTNESS_NIGHT_STORE_FILE} ]; then
+							LVL=`cat ${CS_BRIGHTNESS_NIGHT_STORE_FILE}`
+							echo ${LVL} > ${BRIGHTNESS_FILE}
+							cs_echo "Brightness Level Night Restored"
+						else
+							echo ${BR_MAX} > ${BRIGHTNESS_FILE}
+							cs_echo "Brightness Level Night Restored by default value"
+						fi
+						if [ -f ${CS_BRIGHTNESS_STORE_FILE} ]; then
+							LVL=`cat ${CS_BRIGHTNESS_STORE_FILE}`
+							echo ${LVL} > ${BRIGHTNESS_FILE}
+							cs_echo "Brightness Level Day Restored"
+						else
+							echo ${BR_MAX} > ${BRIGHTNESS_FILE}
+							cs_echo "Brightness Level Day Restored by default value"
+						fi
+					fi
+					;;
+				up)
+					LVL=`cat ${BRIGHTNESS_FILE}`
+					if [ $((${LVL} + ${BR_STEP})) -le ${BR_MAX} ]; then
+						echo $((${LVL} + ${BR_STEP})) > ${BRIGHTNESS_FILE}
+						cs_echo "Brightness Level Increased To: $((${LVL} + ${BR_STEP}))"
+					fi
+					;;
+				down)
+					LVL=`cat ${BRIGHTNESS_FILE}`
+					if [ $((${LVL} - ${BR_STEP})) -ge ${BR_MIN} ]; then
+						echo $((${LVL} - ${BR_STEP})) > ${BRIGHTNESS_FILE}
+						cs_echo "Brightness Level Reduced To: $((${LVL} + ${BR_STEP}))"
+					fi
+				;;
+				min)
+					echo ${BR_MIN} > ${BRIGHTNESS_FILE}
+					cs_echo "Brightness Level Set To Min: ${BR_MIN}"
+					;;
+				max)
+					echo ${BR_MAX} > ${BRIGHTNESS_FILE}
+					cs_echo "Brightness Level Set To Max: ${BR_MAX}"
+					;;
+				get)
+					if [ ! -z $3 ]; then
+						if [ $3 == "location" ]; then
+							echo ${BRIGHTNESS_FILE}
+						elif [ $3 == "level" ]; then
+							# get current brightness level
+							LVL=`cat ${BRIGHTNESS_FILE}`
+							cs_echo "Cutrent Brightness Level: $LVL"
+						else
+							cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness get location|level${RESET}"
+						fi
+					else
+						cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness get location|level${RESET}"
+					fi
+					;;
+				set)
+					if [ ! -z $3 ]; then
+						echo $3 > ${BRIGHTNESS_FILE}
+						cs_echo "Brightness Level Set To Min: $3"
+					fi
+					;;
+				*)
+					cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness save|restore|up|down|min|max|set|get${RESET}"
+					;;
+			esac
 		else
-        	    cs_echo "No device brightness file present"
-
-		fi
-		;;
-	    restore)
-		if [ -f ${BRIGHTNESS_FILE} ]; then
-		    if [ -f /tmp/night_mode_enabled ]; then
-		        if [ -f ${CS_BRIGHTNESS_NIGHT_STORE_FILE} ]; then
-			    LVL=`cat ${CS_BRIGHTNESS_NIGHT_STORE_FILE}`
-			    echo ${LVL} > ${BRIGHTNESS_FILE}
-			    cs_echo "Brightness Level Night Restored"
-		        else
-			    echo ${BR_MAX} > ${BRIGHTNESS_FILE}
-			    cs_echo "Brightness Level Night Restored by default value"
-		        fi
-                    else
-		        if [ -f ${CS_BRIGHTNESS_STORE_FILE} ]; then
-			    LVL=`cat ${CS_BRIGHTNESS_STORE_FILE}`
-			    echo ${LVL} > ${BRIGHTNESS_FILE}
-			    cs_echo "Brightness Level Day Restored"
-		        else
-			    echo ${BR_MAX} > ${BRIGHTNESS_FILE}
-			    cs_echo "Brightness Level Day Restored by default value"
-		        fi
-                    fi
-		else
-    		    cs_echo "No device brightness file present"
-		fi
-		;;
-	    up)
-		if [ -f ${BRIGHTNESS_FILE} ]; then
-		    LVL=`cat ${BRIGHTNESS_FILE}`
-		    if [ $((${LVL} + ${BR_STEP})) -le ${BR_MAX} ]; then
-			echo $((${LVL} + ${BR_STEP})) > ${BRIGHTNESS_FILE}
-			cs_echo "Brightness Level Increased To: $((${LVL} + ${BR_STEP}))"
-		    fi
-		else
-    		    cs_echo "No device brightness file present"
-		fi
-		;;
-	    down)
-		if [ -f ${BRIGHTNESS_FILE} ]; then
-		    LVL=`cat ${BRIGHTNESS_FILE}`
-		    if [ $((${LVL} - ${BR_STEP})) -ge ${BR_MIN} ]; then
-			echo $((${LVL} - ${BR_STEP})) > ${BRIGHTNESS_FILE}
-			cs_echo "Brightness Level Reduced To: $((${LVL} + ${BR_STEP}))"
-		    fi
-		else
-    		    cs_echo "No device brightness file present"
-		fi
-		;;
-	    min)
-		if [ -f ${BRIGHTNESS_FILE} ]; then
-		    echo ${BR_MIN} > ${BRIGHTNESS_FILE}
-		    cs_echo "Brightness Level Set To Min: ${BR_MIN}"
-		else
-		    cs_echo "No device brightness file present"
-		fi
-		;;
-	    max)
-		if [ -f ${BRIGHTNESS_FILE} ]; then
-		    echo ${BR_MAX} > ${BRIGHTNESS_FILE}
-		    cs_echo "Brightness Level Set To Max: ${BR_MAX}"
-		else
-		    cs_echo "No device brightness file present"
-		fi
-		;;
-	    get)
-		if [ ! -z $3 ]; then
-		    if [ $3 == "location" ]; then
-			echo ${BRIGHTNESS_FILE}
-		    elif [ $3 == "level" ]; then
-			if [ -f ${BRIGHTNESS_FILE} ]; then
-			    # get current brightness level
-			    LVL=`cat ${BRIGHTNESS_FILE}`
-			    cs_echo "Cutrent Brightness Level: $LVL"
-			else
-    			    cs_echo "No device brightness file present"
-			fi
-		    else
-			cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness get location|level${RESET}"
-		    fi
-		else
-		    cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness get location|level${RESET}"
-		fi
-		;;
-	    set)
-		if [ ! -z $3 ]; then
-		    if [ -f ${BRIGHTNESS_FILE} ]; then
-			echo $3 > ${BRIGHTNESS_FILE}
-			cs_echo "Brightness Level Set To Min: $3"
-		    else
 			cs_echo "No device brightness file present"
-		    fi
 		fi
-		;;
-	    *)
-		cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness save|restore|up|down|min|max|set|get${RESET}"
-		;;
-	esac
     fi
 
     # filesystem

--- a/csmt/crankshaft
+++ b/csmt/crankshaft
@@ -376,6 +376,7 @@ if [ ! -z $1 ]; then
 							echo ${BR_MAX} > ${BRIGHTNESS_FILE}
 							cs_echo "Brightness Level Night Restored by default value"
 						fi
+					else
 						if [ -f ${CS_BRIGHTNESS_STORE_FILE} ]; then
 							LVL=`cat ${CS_BRIGHTNESS_STORE_FILE}`
 							echo ${LVL} > ${BRIGHTNESS_FILE}

--- a/csmt/crankshaft
+++ b/csmt/crankshaft
@@ -349,88 +349,91 @@ if [ ! -z $1 ]; then
 
     # brightness
     if [ $1 == "brightness" ]; then
-		if [ -f ${BRIGHTNESS_FILE} ]; then
-			case $2 in
-				save)
-					cs_bootrw
-					if [ -f /tmp/night_mode_enabled ]; then
-						sudo sh -c 'cat '${BRIGHTNESS_FILE}' > '${CS_BRIGHTNESS_NIGHT_STORE_FILE}
-						cs_echo "Brightness Level Night Saved"
-					else
-						sudo sh -c 'cat '${BRIGHTNESS_FILE}' > '${CS_BRIGHTNESS_STORE_FILE}
-						cs_echo "Brightness Level Day Saved"
-					fi
-					cs_bootro
-					;;
-				restore)
-					if [ -f /tmp/night_mode_enabled ]; then
-						if [ -f ${CS_BRIGHTNESS_NIGHT_STORE_FILE} ]; then
-							LVL=`cat ${CS_BRIGHTNESS_NIGHT_STORE_FILE}`
-							echo ${LVL} > ${BRIGHTNESS_FILE}
-							cs_echo "Brightness Level Night Restored"
-						else
-							echo ${BR_MAX} > ${BRIGHTNESS_FILE}
-							cs_echo "Brightness Level Night Restored by default value"
-						fi
-						if [ -f ${CS_BRIGHTNESS_STORE_FILE} ]; then
-							LVL=`cat ${CS_BRIGHTNESS_STORE_FILE}`
-							echo ${LVL} > ${BRIGHTNESS_FILE}
-							cs_echo "Brightness Level Day Restored"
-						else
-							echo ${BR_MAX} > ${BRIGHTNESS_FILE}
-							cs_echo "Brightness Level Day Restored by default value"
-						fi
-					fi
-					;;
-				up)
-					LVL=`cat ${BRIGHTNESS_FILE}`
-					if [ $((${LVL} + ${BR_STEP})) -le ${BR_MAX} ]; then
-						echo $((${LVL} + ${BR_STEP})) > ${BRIGHTNESS_FILE}
-						cs_echo "Brightness Level Increased To: $((${LVL} + ${BR_STEP}))"
-					fi
-					;;
-				down)
-					LVL=`cat ${BRIGHTNESS_FILE}`
-					if [ $((${LVL} - ${BR_STEP})) -ge ${BR_MIN} ]; then
-						echo $((${LVL} - ${BR_STEP})) > ${BRIGHTNESS_FILE}
-						cs_echo "Brightness Level Reduced To: $((${LVL} + ${BR_STEP}))"
-					fi
+		if [ ! -f ${BRIGHTNESS_FILE} ] && [ -v $BRIGHTNESS_COMMAND ]; then
+			touch ${BRIGHTNESS_FILE}
+			chmod 666 $BRIGHTNESS_FILE
+		fi
+		case $2 in
+			save)
+				cs_bootrw
+				if [ -f /tmp/night_mode_enabled ]; then
+					sudo sh -c 'cat '${BRIGHTNESS_FILE}' > '${CS_BRIGHTNESS_NIGHT_STORE_FILE}
+					cs_echo "Brightness Level Night Saved"
+				else
+					sudo sh -c 'cat '${BRIGHTNESS_FILE}' > '${CS_BRIGHTNESS_STORE_FILE}
+					cs_echo "Brightness Level Day Saved"
+				fi
+				cs_bootro
 				;;
-				min)
-					echo ${BR_MIN} > ${BRIGHTNESS_FILE}
-					cs_echo "Brightness Level Set To Min: ${BR_MIN}"
-					;;
-				max)
-					echo ${BR_MAX} > ${BRIGHTNESS_FILE}
-					cs_echo "Brightness Level Set To Max: ${BR_MAX}"
-					;;
-				get)
-					if [ ! -z $3 ]; then
-						if [ $3 == "location" ]; then
-							echo ${BRIGHTNESS_FILE}
-						elif [ $3 == "level" ]; then
-							# get current brightness level
-							LVL=`cat ${BRIGHTNESS_FILE}`
-							cs_echo "Cutrent Brightness Level: $LVL"
-						else
-							cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness get location|level${RESET}"
-						fi
+			restore)
+				if [ -f /tmp/night_mode_enabled ]; then
+					if [ -f ${CS_BRIGHTNESS_NIGHT_STORE_FILE} ]; then
+						LVL=`cat ${CS_BRIGHTNESS_NIGHT_STORE_FILE}`
+						echo ${LVL} > ${BRIGHTNESS_FILE}
+						cs_echo "Brightness Level Night Restored"
+					else
+						echo ${BR_MAX} > ${BRIGHTNESS_FILE}
+						cs_echo "Brightness Level Night Restored by default value"
+					fi
+					if [ -f ${CS_BRIGHTNESS_STORE_FILE} ]; then
+						LVL=`cat ${CS_BRIGHTNESS_STORE_FILE}`
+						echo ${LVL} > ${BRIGHTNESS_FILE}
+						cs_echo "Brightness Level Day Restored"
+					else
+						echo ${BR_MAX} > ${BRIGHTNESS_FILE}
+						cs_echo "Brightness Level Day Restored by default value"
+					fi
+				fi
+				;;
+			up)
+				LVL=`cat ${BRIGHTNESS_FILE}`
+				if [ $((${LVL} + ${BR_STEP})) -le ${BR_MAX} ]; then
+					echo $((${LVL} + ${BR_STEP})) > ${BRIGHTNESS_FILE}
+					cs_echo "Brightness Level Increased To: $((${LVL} + ${BR_STEP}))"
+				fi
+				;;
+			down)
+				LVL=`cat ${BRIGHTNESS_FILE}`
+				if [ $((${LVL} - ${BR_STEP})) -ge ${BR_MIN} ]; then
+					echo $((${LVL} - ${BR_STEP})) > ${BRIGHTNESS_FILE}
+					cs_echo "Brightness Level Reduced To: $((${LVL} + ${BR_STEP}))"
+				fi
+			;;
+			min)
+				echo ${BR_MIN} > ${BRIGHTNESS_FILE}
+				cs_echo "Brightness Level Set To Min: ${BR_MIN}"
+				;;
+			max)
+				echo ${BR_MAX} > ${BRIGHTNESS_FILE}
+				cs_echo "Brightness Level Set To Max: ${BR_MAX}"
+				;;
+			get)
+				if [ ! -z $3 ]; then
+					if [ $3 == "location" ]; then
+						echo ${BRIGHTNESS_FILE}
+					elif [ $3 == "level" ]; then
+						# get current brightness level
+						LVL=`cat ${BRIGHTNESS_FILE}`
+						cs_echo "Cutrent Brightness Level: $LVL"
 					else
 						cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness get location|level${RESET}"
 					fi
-					;;
-				set)
-					if [ ! -z $3 ]; then
-						echo $3 > ${BRIGHTNESS_FILE}
-						cs_echo "Brightness Level Set To Min: $3"
-					fi
-					;;
-				*)
-					cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness save|restore|up|down|min|max|set|get${RESET}"
-					;;
-			esac
-		else
-			cs_echo "No device brightness file present"
+				else
+					cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness get location|level${RESET}"
+				fi
+				;;
+			set)
+				if [ ! -z $3 ]; then
+					echo $3 > ${BRIGHTNESS_FILE}
+					cs_echo "Brightness Level Set To Min: $3"
+				fi
+				;;
+			*)
+				cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness save|restore|up|down|min|max|set|get${RESET}"
+				;;
+		esac
+		if [ -v $BRIGHTNESS_COMMAND ]; then
+			eval $BRIGHTNESS_COMMAND
 		fi
     fi
 

--- a/csmt/crankshaft
+++ b/csmt/crankshaft
@@ -349,7 +349,7 @@ if [ ! -z $1 ]; then
 
     # brightness
     if [ $1 == "brightness" ]; then
-		if [ ! -f ${BRIGHTNESS_FILE} ] && [ -v $BRIGHTNESS_COMMAND ]; then
+		if [ ! -f ${BRIGHTNESS_FILE} ] && [ ! -z $BRIGHTNESS_COMMAND ]; then
 			touch ${BRIGHTNESS_FILE}
 			chmod 666 $BRIGHTNESS_FILE
 		fi
@@ -442,8 +442,8 @@ if [ ! -z $1 ]; then
 		else
 			cs_echo "No device brightness file present"
 		fi
-		if [ -v $BRIGHTNESS_COMMAND ]; then
-			eval $BRIGHTNESS_COMMAND
+		if [ ! -z $BRIGHTNESS_COMMAND ]; then
+			eval $BRIGHTNESS_COMMAND `cat ${BRIGHTNESS_FILE}`
 		fi
     fi
 

--- a/csmt/crankshaft
+++ b/csmt/crankshaft
@@ -391,6 +391,9 @@ if [ ! -z $1 ]; then
 					if [ $((${LVL} + ${BR_STEP})) -le ${BR_MAX} ]; then
 						echo $((${LVL} + ${BR_STEP})) > ${BRIGHTNESS_FILE}
 						cs_echo "Brightness Level Increased To: $((${LVL} + ${BR_STEP}))"
+					else
+						echo ${BR_MAX} > ${BRIGHTNESS_FILE}
+						cs_echo "Brightness Level Set To Max: ${BR_MAX}"
 					fi
 					;;
 				down)
@@ -398,6 +401,9 @@ if [ ! -z $1 ]; then
 					if [ $((${LVL} - ${BR_STEP})) -ge ${BR_MIN} ]; then
 						echo $((${LVL} - ${BR_STEP})) > ${BRIGHTNESS_FILE}
 						cs_echo "Brightness Level Reduced To: $((${LVL} + ${BR_STEP}))"
+					else
+						echo ${BR_MIN} > ${BRIGHTNESS_FILE}
+						cs_echo "Brightness Level Set To Min: ${BR_MIN}"
 					fi
 				;;
 				min)
@@ -426,7 +432,7 @@ if [ ! -z $1 ]; then
 				set)
 					if [ ! -z $3 ]; then
 						echo $3 > ${BRIGHTNESS_FILE}
-						cs_echo "Brightness Level Set To Min: $3"
+						cs_echo "Brightness Level Set To: $3"
 					fi
 					;;
 				*)

--- a/csmt/crankshaft
+++ b/csmt/crankshaft
@@ -353,85 +353,89 @@ if [ ! -z $1 ]; then
 			touch ${BRIGHTNESS_FILE}
 			chmod 666 $BRIGHTNESS_FILE
 		fi
-		case $2 in
-			save)
-				cs_bootrw
-				if [ -f /tmp/night_mode_enabled ]; then
-					sudo sh -c 'cat '${BRIGHTNESS_FILE}' > '${CS_BRIGHTNESS_NIGHT_STORE_FILE}
-					cs_echo "Brightness Level Night Saved"
-				else
-					sudo sh -c 'cat '${BRIGHTNESS_FILE}' > '${CS_BRIGHTNESS_STORE_FILE}
-					cs_echo "Brightness Level Day Saved"
-				fi
-				cs_bootro
-				;;
-			restore)
-				if [ -f /tmp/night_mode_enabled ]; then
-					if [ -f ${CS_BRIGHTNESS_NIGHT_STORE_FILE} ]; then
-						LVL=`cat ${CS_BRIGHTNESS_NIGHT_STORE_FILE}`
-						echo ${LVL} > ${BRIGHTNESS_FILE}
-						cs_echo "Brightness Level Night Restored"
+		if [ -f ${BRIGHTNESS_FILE} ]; then
+			case $2 in
+				save)
+					cs_bootrw
+					if [ -f /tmp/night_mode_enabled ]; then
+						sudo sh -c 'cat '${BRIGHTNESS_FILE}' > '${CS_BRIGHTNESS_NIGHT_STORE_FILE}
+						cs_echo "Brightness Level Night Saved"
 					else
-						echo ${BR_MAX} > ${BRIGHTNESS_FILE}
-						cs_echo "Brightness Level Night Restored by default value"
+						sudo sh -c 'cat '${BRIGHTNESS_FILE}' > '${CS_BRIGHTNESS_STORE_FILE}
+						cs_echo "Brightness Level Day Saved"
 					fi
-					if [ -f ${CS_BRIGHTNESS_STORE_FILE} ]; then
-						LVL=`cat ${CS_BRIGHTNESS_STORE_FILE}`
-						echo ${LVL} > ${BRIGHTNESS_FILE}
-						cs_echo "Brightness Level Day Restored"
-					else
-						echo ${BR_MAX} > ${BRIGHTNESS_FILE}
-						cs_echo "Brightness Level Day Restored by default value"
+					cs_bootro
+					;;
+				restore)
+					if [ -f /tmp/night_mode_enabled ]; then
+						if [ -f ${CS_BRIGHTNESS_NIGHT_STORE_FILE} ]; then
+							LVL=`cat ${CS_BRIGHTNESS_NIGHT_STORE_FILE}`
+							echo ${LVL} > ${BRIGHTNESS_FILE}
+							cs_echo "Brightness Level Night Restored"
+						else
+							echo ${BR_MAX} > ${BRIGHTNESS_FILE}
+							cs_echo "Brightness Level Night Restored by default value"
+						fi
+						if [ -f ${CS_BRIGHTNESS_STORE_FILE} ]; then
+							LVL=`cat ${CS_BRIGHTNESS_STORE_FILE}`
+							echo ${LVL} > ${BRIGHTNESS_FILE}
+							cs_echo "Brightness Level Day Restored"
+						else
+							echo ${BR_MAX} > ${BRIGHTNESS_FILE}
+							cs_echo "Brightness Level Day Restored by default value"
+						fi
 					fi
-				fi
+					;;
+				up)
+					LVL=`cat ${BRIGHTNESS_FILE}`
+					if [ $((${LVL} + ${BR_STEP})) -le ${BR_MAX} ]; then
+						echo $((${LVL} + ${BR_STEP})) > ${BRIGHTNESS_FILE}
+						cs_echo "Brightness Level Increased To: $((${LVL} + ${BR_STEP}))"
+					fi
+					;;
+				down)
+					LVL=`cat ${BRIGHTNESS_FILE}`
+					if [ $((${LVL} - ${BR_STEP})) -ge ${BR_MIN} ]; then
+						echo $((${LVL} - ${BR_STEP})) > ${BRIGHTNESS_FILE}
+						cs_echo "Brightness Level Reduced To: $((${LVL} + ${BR_STEP}))"
+					fi
 				;;
-			up)
-				LVL=`cat ${BRIGHTNESS_FILE}`
-				if [ $((${LVL} + ${BR_STEP})) -le ${BR_MAX} ]; then
-					echo $((${LVL} + ${BR_STEP})) > ${BRIGHTNESS_FILE}
-					cs_echo "Brightness Level Increased To: $((${LVL} + ${BR_STEP}))"
-				fi
-				;;
-			down)
-				LVL=`cat ${BRIGHTNESS_FILE}`
-				if [ $((${LVL} - ${BR_STEP})) -ge ${BR_MIN} ]; then
-					echo $((${LVL} - ${BR_STEP})) > ${BRIGHTNESS_FILE}
-					cs_echo "Brightness Level Reduced To: $((${LVL} + ${BR_STEP}))"
-				fi
-			;;
-			min)
-				echo ${BR_MIN} > ${BRIGHTNESS_FILE}
-				cs_echo "Brightness Level Set To Min: ${BR_MIN}"
-				;;
-			max)
-				echo ${BR_MAX} > ${BRIGHTNESS_FILE}
-				cs_echo "Brightness Level Set To Max: ${BR_MAX}"
-				;;
-			get)
-				if [ ! -z $3 ]; then
-					if [ $3 == "location" ]; then
-						echo ${BRIGHTNESS_FILE}
-					elif [ $3 == "level" ]; then
-						# get current brightness level
-						LVL=`cat ${BRIGHTNESS_FILE}`
-						cs_echo "Cutrent Brightness Level: $LVL"
+				min)
+					echo ${BR_MIN} > ${BRIGHTNESS_FILE}
+					cs_echo "Brightness Level Set To Min: ${BR_MIN}"
+					;;
+				max)
+					echo ${BR_MAX} > ${BRIGHTNESS_FILE}
+					cs_echo "Brightness Level Set To Max: ${BR_MAX}"
+					;;
+				get)
+					if [ ! -z $3 ]; then
+						if [ $3 == "location" ]; then
+							echo ${BRIGHTNESS_FILE}
+						elif [ $3 == "level" ]; then
+							# get current brightness level
+							LVL=`cat ${BRIGHTNESS_FILE}`
+							cs_echo "Cutrent Brightness Level: $LVL"
+						else
+							cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness get location|level${RESET}"
+						fi
 					else
 						cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness get location|level${RESET}"
 					fi
-				else
-					cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness get location|level${RESET}"
-				fi
-				;;
-			set)
-				if [ ! -z $3 ]; then
-					echo $3 > ${BRIGHTNESS_FILE}
-					cs_echo "Brightness Level Set To Min: $3"
-				fi
-				;;
-			*)
-				cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness save|restore|up|down|min|max|set|get${RESET}"
-				;;
-		esac
+					;;
+				set)
+					if [ ! -z $3 ]; then
+						echo $3 > ${BRIGHTNESS_FILE}
+						cs_echo "Brightness Level Set To Min: $3"
+					fi
+					;;
+				*)
+					cs_echo "${YELLOW}${BOLD}Syntax: crankshaft brightness save|restore|up|down|min|max|set|get${RESET}"
+					;;
+			esac
+		else
+			cs_echo "No device brightness file present"
+		fi
 		if [ -v $BRIGHTNESS_COMMAND ]; then
 			eval $BRIGHTNESS_COMMAND
 		fi


### PR DESCRIPTION
I'm using a screen which wants a pwm brightness signal. I have edit the `crankshaft` command to include a custom command which will be ran after a brightness change with the brightness value as argument. So the user can trigger his own program on brightness change.

`BRIGHTNESS_COMMAND=` must be set in `crankshaft_env.sh`
I'm now looking for making a pull request to the `crankshaftng` for the `crankshaft_env.sh`. It should include:
`# Brightness related stuff`
`# When using custom brightness control you can set the BRIGHTNESS_COMMAND which will be executed on brightness change`
`# Set BRIGHTNESS_FILE to somewhere with write access when using BRIGHTNESS_COMMAND you can use "/tmp/brightness" or similar`
`BRIGHTNESS_FILE=/sys/class/backlight/rpi_backlight/brightness`
`BRIGHTNESS_COMMAND=`
`BR_MIN=30`
`BR_MAX=255`
`BR_STEP=25`